### PR TITLE
Pandas 2+ compatibility

### DIFF
--- a/.github/workflows/unnittests.yml
+++ b/.github/workflows/unnittests.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-20.04, ubuntu-18.04, macos-latest]
-        python-version: ['3.8', '3.9']
+        python-version: ['3.11', '3.10', '3.9']
     steps:
     -
       uses: actions/setup-python@v3

--- a/classifier/classify.py
+++ b/classifier/classify.py
@@ -234,9 +234,9 @@ def action(args):
 
     # if alignments contains a header row, set header=0 for read_csv
     if 'pident' in header:
-        header_arg=0
+        header_row=0
     else:
-        header_arg=None
+        header_row=None
         
     if args.columns:
         conv = ALIGNMENT_CONVERT
@@ -251,7 +251,7 @@ def action(args):
     aligns = pd.read_csv(
         args.alignments,
         dtype=ALIGNMENT_DTYPES,
-        header=header_arg,
+        header=header_row,
         names=names,
         sep=sep)
 

--- a/classifier/classify.py
+++ b/classifier/classify.py
@@ -231,6 +231,13 @@ def action(args):
         sep = '\t'
     else:
         sep = ','
+
+    # if alignments contains a header row, set header=0 for read_csv
+    if 'pident' in header:
+        header_arg=0
+    else:
+        header_arg=None
+        
     if args.columns:
         conv = ALIGNMENT_CONVERT
         names = [conv.get(c, c) for c in args.columns.split(sep)]
@@ -244,7 +251,7 @@ def action(args):
     aligns = pd.read_csv(
         args.alignments,
         dtype=ALIGNMENT_DTYPES,
-        header=0,
+        header=header_arg,
         names=names,
         sep=sep)
 

--- a/classifier/classify.py
+++ b/classifier/classify.py
@@ -244,6 +244,7 @@ def action(args):
     aligns = pd.read_csv(
         args.alignments,
         dtype=ALIGNMENT_DTYPES,
+        header=0,
         names=names,
         sep=sep)
 
@@ -398,7 +399,7 @@ def action(args):
         # see select_best_hits for how *_level are used
     best_hits = aligns[~aligns['threshold_level'].isna()]
     if not best_hits.empty:
-        spec_group = best_hits.groupby(by=['specimen', 'qseqid'])
+        spec_group = best_hits.groupby(by=['specimen', 'qseqid'], group_keys=False)
         sub_cols = [
             'threshold_level', 'assignment_level',
             'threshold_level_threshold', 'assignment_level_threshold']
@@ -470,7 +471,7 @@ def action(args):
 
         # assign names to assignment_hashes
         logging.info('creating compound assignments')
-        name_grp = aligns.groupby(by=['specimen', 'assignment_hash'])
+        name_grp = aligns.groupby(by=['specimen', 'assignment_hash'], group_keys=False)
         name_grp = name_grp[['condensed_tax_name', 'starred']]
         aligns[['assignment']] = name_grp.apply(assign)
 
@@ -507,7 +508,8 @@ def action(args):
         dtypes = aligns.dtypes
 
     # add back qseqids that have no hits back into aligns
-    aligns = pd.concat([aligns, qseqids])
+    if not qseqids.empty:
+        aligns = pd.concat([aligns, qseqids])
     aligns = aligns.astype(dtypes)
 
     # concludes our alignment details, on to output summary


### PR DESCRIPTION
@crosenth couple changes here to remove deprecation warnings and errors when pandas >2 is installed (specifically tested with 2.1.2). 

Note that I've also got a change here to conditionally set the 'header' argument for the `read_csv` action on the alignments file, so that if the file happens to contain a header row, this is explicitly over-ridden via the `names` param. See 'names' entry in the [docs](https://pandas.pydata.org/docs/reference/api/pandas.read_csv.html) for reasoning. 