### PR TITLE
require columns provided via cli arg to be comma separated

### DIFF
--- a/src/classify.py
+++ b/src/classify.py
@@ -240,7 +240,7 @@ def action(args):
 
     if args.columns:
         conv = ALIGNMENT_CONVERT
-        names = [conv.get(c, c) for c in args.columns.split(sep)]
+        names = [conv.get(c, c) for c in args.columns.split(',')]
     elif all(c in header for c in ['qseqid', 'sseqid', 'pident']):
         names = None
     else:
@@ -740,7 +740,7 @@ def build_parser():
     columns_parser.add_argument(
         '--columns', '-c',
         metavar='',
-        help=('specify columns for header-less comma-seperated values'))
+        help=('specify columns for header-less alignments, separated by comma'))
 
     selection_parser = parser.add_argument_group('selection options')
     selection_parser = selection_parser.add_mutually_exclusive_group(


### PR DESCRIPTION
- don't attempt to split the provided args.comma list on the sniffed value of 'sep', which could be a tab in the case of blast outfmt 6